### PR TITLE
cl-who from github

### DIFF
--- a/cl-who/source.txt
+++ b/cl-who/source.txt
@@ -1,1 +1,1 @@
-ediware-http cl-who
+git git://github.com/edicl/cl-who.git


### PR DESCRIPTION
It seems edi is using github now: http://weitz.de/patches.html
The version there does html5, which is what I care about, and probably other stuff as well.
