### PR TITLE
get uuid from github instead from homepage

### DIFF
--- a/uuid/source.txt
+++ b/uuid/source.txt
@@ -1,1 +1,1 @@
-http http://www.dardoria.net/software/uuid.tar.gz
+git git://github.com/dardoria/uuid.git


### PR DESCRIPTION
Can you please change the source for uuid to retrieve it from the github repo instead from dardoria.net

Thanks
