### PR TITLE
Please add CL-Fuse-Meta-FS

### DIFF
--- a/cl-fuse-meta-fs/source.txt
+++ b/cl-fuse-meta-fs/source.txt
@@ -1,0 +1,1 @@
+git git://github.com/fb08af68/cl-fuse-meta-fs.git


### PR DESCRIPTION
Please add CL-Fuse-Meta-FS, a lispy wrapper around CL-FUSE.

Source is as specified in the pull request, git mirror at `https://github.com/fb08af68/cl-fuse-meta-fs.git`

It requires Quicklisp-installable package `pcall` in addition to CL-FUSE and its dependencies.

Project page: http://mtn-host.prjek.net/projects/cl-fuse/

http://common-lisp.net/project/cl-fuse/ (common-lisp.net page)

Is there anything except source.txt that I should add in the pull request?
