### PR TITLE
Use moptilities from github

### DIFF
--- a/moptilities/source.txt
+++ b/moptilities/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/moptilities/moptilities_latest.tar.gz
+git git://github.com/gwkkwg/moptilities.git


### PR DESCRIPTION
The moptilities recent fixes are published on github, but not on the tarball.
