### PR TITLE
Changed location of CL-MW repository from UW-Madison to Github.

### DIFF
--- a/cl-mw/source.txt
+++ b/cl-mw/source.txt
@@ -1,1 +1,1 @@
-git http://pages.cs.wisc.edu/~psilord/lisp-public/public-repos-lisp/cl-mw.git
+git https://github.com/psilord/cl-mw.git


### PR DESCRIPTION
I have fixed my code to not use the depreciated SBCL sb-ext:exit function (and a few other fixes too).