### PR TITLE
common-lisp.net is now doing automatic HTTP to HTTPS redirect 

### DIFF
--- a/adw-charting/source.txt
+++ b/adw-charting/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/adw-charting/adw-charting.tar.gz
+https https://common-lisp.net/project/adw-charting/adw-charting.tar.gz

--- a/anaphora/source.txt
+++ b/anaphora/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/anaphora/files/anaphora-latest.tar.gz
+https https://common-lisp.net/project/anaphora/files/anaphora-latest.tar.gz

--- a/arnesi/source.txt
+++ b/arnesi/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/bese/repos/arnesi_dev/
+darcs https://common-lisp.net/project/bese/repos/arnesi_dev/

--- a/asn.1/source.txt
+++ b/asn.1/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-net-snmp/release/asn.1_latest.tar.gz
+https https://common-lisp.net/project/cl-net-snmp/release/asn.1_latest.tar.gz

--- a/bordeaux-threads/source.txt
+++ b/bordeaux-threads/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/bordeaux-threads/releases/bordeaux-threads-0.8.3.tar.gz
+https https://common-lisp.net/project/bordeaux-threads/releases/bordeaux-threads-0.8.3.tar.gz

--- a/chemical-compounds/source.txt
+++ b/chemical-compounds/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/chemboy/chemical-compounds-latest.tar.gz
+https https://common-lisp.net/project/chemboy/chemical-compounds-latest.tar.gz

--- a/cl-cont/source.txt
+++ b/cl-cont/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/cl-cont/darcs/cl-cont
+darcs https://common-lisp.net/project/cl-cont/darcs/cl-cont

--- a/cl-heap/source.txt
+++ b/cl-heap/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-heap/releases/cl-heap_latest.tar.gz
+https https://common-lisp.net/project/cl-heap/releases/cl-heap_latest.tar.gz

--- a/cl-irc/source.txt
+++ b/cl-irc/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-irc/releases/cl-irc_latest.tar.gz
+https https://common-lisp.net/project/cl-irc/releases/cl-irc_latest.tar.gz

--- a/cl-l10n-cldr/source.txt
+++ b/cl-l10n-cldr/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/cl-l10n/repos/cl-l10n-cldr/
+darcs https://common-lisp.net/project/cl-l10n/repos/cl-l10n-cldr/

--- a/cl-l10n/source.txt
+++ b/cl-l10n/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/cl-l10n/repos/cl-l10n
+darcs https://common-lisp.net/project/cl-l10n/repos/cl-l10n

--- a/cl-markdown/source.txt
+++ b/cl-markdown/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/cl-markdown
+darcs https://common-lisp.net/project/cl-markdown

--- a/cl-migrations/source.txt
+++ b/cl-migrations/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-migrations/cl-migrations-latest.tgz
+https https://common-lisp.net/project/cl-migrations/cl-migrations-latest.tgz

--- a/cl-muproc/source.txt
+++ b/cl-muproc/source.txt
@@ -1,1 +1,1 @@
-http http://www.common-lisp.net/project/cl-muproc/cl-muproc.tar.gz
+https https://www.common-lisp.net/project/cl-muproc/cl-muproc.tar.gz

--- a/cl-ncurses/source.txt
+++ b/cl-ncurses/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-ncurses/files/cl-ncurses_latest-version.tgz
+https https://common-lisp.net/project/cl-ncurses/files/cl-ncurses_latest-version.tgz

--- a/cl-pop/source.txt
+++ b/cl-pop/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-pop/cl-pop.tar.gz
+https https://common-lisp.net/project/cl-pop/cl-pop.tar.gz

--- a/cl-stm/source.txt
+++ b/cl-stm/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-stm/latest.tar.gz
+https https://common-lisp.net/project/cl-stm/latest.tar.gz

--- a/cl-utilities/source.txt
+++ b/cl-utilities/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-utilities/cl-utilities-latest.tar.gz
+https https://common-lisp.net/project/cl-utilities/cl-utilities-latest.tar.gz

--- a/cl-variates/source.txt
+++ b/cl-variates/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/cl-variates
+darcs https://common-lisp.net/project/cl-variates

--- a/cl-xmlspam/source.txt
+++ b/cl-xmlspam/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-xmlspam/cl-xmlspam.tgz
+https https://common-lisp.net/project/cl-xmlspam/cl-xmlspam.tgz

--- a/cl-xmpp/source.txt
+++ b/cl-xmpp/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-xmpp/cl-xmpp_latest.tar.gz
+https https://common-lisp.net/project/cl-xmpp/cl-xmpp_latest.tar.gz

--- a/clnuplot/source.txt
+++ b/clnuplot/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/clnuplot
+darcs https://common-lisp.net/project/clnuplot

--- a/clouchdb/source.txt
+++ b/clouchdb/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/clouchdb/clouchdb-latest.tar.gz
+https https://common-lisp.net/project/clouchdb/clouchdb-latest.tar.gz

--- a/date-calc/source.txt
+++ b/date-calc/source.txt
@@ -1,1 +1,1 @@
-naked-http http://common-lisp.net/project/cl-date-calc/date-calc-0.3.tar.gz
+naked-https https://common-lisp.net/project/cl-date-calc/date-calc-0.3.tar.gz

--- a/defsystem-compatibility/source.txt
+++ b/defsystem-compatibility/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/cl-containers/defsystem-compatibility/
+darcs https://common-lisp.net/project/cl-containers/defsystem-compatibility/

--- a/eager-future/source.txt
+++ b/eager-future/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/eager-future/repository/eager-future/
+darcs https://common-lisp.net/project/eager-future/repository/eager-future/

--- a/eager-future2/source.txt
+++ b/eager-future2/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/eager-future/release/eager-future2-0.2.tgz
+https https://common-lisp.net/project/eager-future/release/eager-future2-0.2.tgz

--- a/elephant/source.txt
+++ b/elephant/source.txt
@@ -1,1 +1,1 @@
-darcs http://www.common-lisp.net/project/elephant/darcs/elephant-1.0
+darcs https://www.common-lisp.net/project/elephant/darcs/elephant-1.0

--- a/f-underscore/source.txt
+++ b/f-underscore/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/bpm/darcs/f-underscore
+darcs https://common-lisp.net/project/bpm/darcs/f-underscore

--- a/filtered-functions/source.txt
+++ b/filtered-functions/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/closer/repos/filtered-functions/
+darcs https://common-lisp.net/project/closer/repos/filtered-functions/

--- a/fiveam/source.txt
+++ b/fiveam/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/fiveam/files/fiveam-latest.tar.gz
+https https://common-lisp.net/project/fiveam/files/fiveam-latest.tar.gz

--- a/flexichain/source.txt
+++ b/flexichain/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/flexichain/download/flexichain_latest.tgz
+https https://common-lisp.net/project/flexichain/download/flexichain_latest.tgz

--- a/fucc/source.txt
+++ b/fucc/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/fucc/files/fucc_0.2.1-alpha-20080624.tar.gz
+https https://common-lisp.net/project/fucc/files/fucc_0.2.1-alpha-20080624.tar.gz

--- a/funds/source.txt
+++ b/funds/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/funds/funds.tar.gz
+https https://common-lisp.net/project/funds/funds.tar.gz

--- a/gzip-stream/source.txt
+++ b/gzip-stream/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/gzip-stream/files/gzip-stream_latest.tgz
+https https://common-lisp.net/project/gzip-stream/files/gzip-stream_latest.tgz

--- a/ht-ajax/source.txt
+++ b/ht-ajax/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/ht-ajax/files/ht-ajax.tar.gz
+https https://common-lisp.net/project/ht-ajax/files/ht-ajax.tar.gz

--- a/iterate-clsql/source.txt
+++ b/iterate-clsql/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/iterate-clsql/releases/iterate-clsql-0.2.tar.gz
+https https://common-lisp.net/project/iterate-clsql/releases/iterate-clsql-0.2.tar.gz

--- a/metatilities/source.txt
+++ b/metatilities/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/metatilities
+darcs https://common-lisp.net/project/metatilities

--- a/mop-utils/source.txt
+++ b/mop-utils/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/submarine/mop-utils.tar.gz
+https https://common-lisp.net/project/submarine/mop-utils.tar.gz

--- a/mt19937/source.txt
+++ b/mt19937/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/asdf-packaging/mt19937-latest.tar.gz
+https https://common-lisp.net/project/asdf-packaging/mt19937-latest.tar.gz

--- a/parenscript/source.txt
+++ b/parenscript/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/parenscript/release/parenscript-latest.tgz
+https https://common-lisp.net/project/parenscript/release/parenscript-latest.tgz

--- a/parse-declarations/source.txt
+++ b/parse-declarations/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/parse-declarations/darcs/parse-declarations
+darcs https://common-lisp.net/project/parse-declarations/darcs/parse-declarations

--- a/periodic-table/source.txt
+++ b/periodic-table/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/chemboy/periodic-table-latest.tar.gz
+https https://common-lisp.net/project/chemboy/periodic-table-latest.tar.gz

--- a/psgraph/source.txt
+++ b/psgraph/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/asdf-packaging/psgraph-latest.tar.gz
+https https://common-lisp.net/project/asdf-packaging/psgraph-latest.tar.gz

--- a/qbook/source.txt
+++ b/qbook/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/bese/repos/qbook/
+darcs https://common-lisp.net/project/bese/repos/qbook/

--- a/rfc2109/source.txt
+++ b/rfc2109/source.txt
@@ -1,1 +1,1 @@
-darcs http://www.common-lisp.net/project/rfc2109/rfc2109/
+darcs https://www.common-lisp.net/project/rfc2109/rfc2109/

--- a/rfc2388-binary/source.txt
+++ b/rfc2388-binary/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/ucw/darcs/rfc2388-binary/
+darcs https://common-lisp.net/project/ucw/darcs/rfc2388-binary/

--- a/s-xml-rpc/source.txt
+++ b/s-xml-rpc/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/s-xml-rpc/s-xml-rpc.tgz
+https https://common-lisp.net/project/s-xml-rpc/s-xml-rpc.tgz

--- a/sapaclisp/source.txt
+++ b/sapaclisp/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/sapaclisp/sapaclisp-1.0a.tgz
+https https://common-lisp.net/project/sapaclisp/sapaclisp-1.0a.tgz

--- a/sequence-iterators/source.txt
+++ b/sequence-iterators/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/sequence-iterators/darcs/sequence-iterators/
+darcs https://common-lisp.net/project/sequence-iterators/darcs/sequence-iterators/

--- a/snmp/source.txt
+++ b/snmp/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-net-snmp/release/snmp_latest.tar.gz
+https https://common-lisp.net/project/cl-net-snmp/release/snmp_latest.tar.gz

--- a/stefil/source.txt
+++ b/stefil/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/stefil/darcs/stefil
+darcs https://common-lisp.net/project/stefil/darcs/stefil

--- a/submarine/source.txt
+++ b/submarine/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/submarine/darcs/submarine/
+darcs https://common-lisp.net/project/submarine/darcs/submarine/

--- a/text-query/source.txt
+++ b/text-query/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/asdf-packaging/text-query-latest.tar.gz
+https https://common-lisp.net/project/asdf-packaging/text-query-latest.tar.gz

--- a/trivial-http/source.txt
+++ b/trivial-http/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/trivial-http/trivial-http.tar.gz
+https https://common-lisp.net/project/trivial-https/trivial-https.tar.gz

--- a/trivial-timeout/source.txt
+++ b/trivial-timeout/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/trivial-timeout/
+darcs https://common-lisp.net/project/trivial-timeout/

--- a/ucw/source.txt
+++ b/ucw/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/ucw/repos/ucw-core/
+darcs https://common-lisp.net/project/ucw/repos/ucw-core/

--- a/uiop/source.txt
+++ b/uiop/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/asdf/archives/uiop.tar.gz
+https https://common-lisp.net/project/asdf/archives/uiop.tar.gz

--- a/uri-template/source.txt
+++ b/uri-template/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/uri-template/release/uri-template-latest.tgz
+https https://common-lisp.net/project/uri-template/release/uri-template-latest.tgz

--- a/usocket-udp/source.txt
+++ b/usocket-udp/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/cl-net-snmp/release/usocket-udp_latest.tar.gz
+https https://common-lisp.net/project/cl-net-snmp/release/usocket-udp_latest.tar.gz

--- a/verrazano/source.txt
+++ b/verrazano/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/fetter/darcs/verrazano/
+darcs https://common-lisp.net/project/fetter/darcs/verrazano/

--- a/xml-emitter/source.txt
+++ b/xml-emitter/source.txt
@@ -1,1 +1,1 @@
-http http://common-lisp.net/project/asdf-packaging/xml-emitter-latest.tar.gz
+https https://common-lisp.net/project/asdf-packaging/xml-emitter-latest.tar.gz

--- a/yaclml/source.txt
+++ b/yaclml/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/bese/repos/yaclml/
+darcs https://common-lisp.net/project/bese/repos/yaclml/


### PR DESCRIPTION
(good on them), however methods and URLs in source.txt files need to be updated. They are now.