### PR TITLE
Updated clsql-fluid repository

### DIFF
--- a/clsql-fluid/source-disabled.txt
+++ b/clsql-fluid/source-disabled.txt
@@ -1,0 +1,1 @@
+darcs http://common-lisp.net/project/clsql-fluid/darcs/clsql-fluid/

--- a/clsql-fluid/source.txt
+++ b/clsql-fluid/source.txt
@@ -1,1 +1,1 @@
-darcs http://common-lisp.net/project/clsql-fluid/darcs/clsql-fluid/
+git git://github.com/html/clsql-fluid.git


### PR DESCRIPTION
Hi. Weblocks repository url is changed to https://github.com/weblocks-framework/weblocks.git
Tell me if my update is ok and merge it please.