### PR TITLE
Move sjl's projects

### DIFF
--- a/projects/adopt/source.txt
+++ b/projects/adopt/source.txt
@@ -1,1 +1,1 @@
-mercurial https://bitbucket.org/sjl/adopt
+mercurial https://hg.stevelosh.com/adopt

--- a/projects/beast/source.txt
+++ b/projects/beast/source.txt
@@ -1,1 +1,1 @@
-git https://github.com/sjl/beast.git
+mercurial https://hg.stevelosh.com/beast

--- a/projects/bobbin/source.txt
+++ b/projects/bobbin/source.txt
@@ -1,1 +1,1 @@
-mercurial https://bitbucket.org/sjl/bobbin
+mercurial https://hg.stevelosh.com/bobbin

--- a/projects/chancery/source.txt
+++ b/projects/chancery/source.txt
@@ -1,1 +1,1 @@
-mercurial https://bitbucket.org/sjl/chancery
+mercurial https://hg.stevelosh.com/chancery

--- a/projects/cl-digraph/source.txt
+++ b/projects/cl-digraph/source.txt
@@ -1,1 +1,1 @@
-mercurial https://bitbucket.org/sjl/cl-digraph/
+mercurial https://hg.stevelosh.com/cl-digraph/

--- a/projects/cl-netpbm/source.txt
+++ b/projects/cl-netpbm/source.txt
@@ -1,1 +1,1 @@
-mercurial https://bitbucket.org/sjl/cl-netpbm
+mercurial https://hg.stevelosh.com/cl-netpbm

--- a/projects/cl-pcg/source.txt
+++ b/projects/cl-pcg/source.txt
@@ -1,1 +1,1 @@
-git https://github.com/sjl/cl-pcg.git
+mercurial https://hg.stevelosh.com/cl-pcg


### PR DESCRIPTION
Bitbucket is ending support for Mercurial projects.  I've set up my own Mercurial hosting so I won't have to do this again in the future.

I know you say no pull requests to this repo, but I asked you in IRC and you said this case might be an exception, so here you go.