### PR TITLE
Update cl-cron source because old repo on BitBucked is not available …

### DIFF
--- a/projects/cl-cron/source.txt
+++ b/projects/cl-cron/source.txt
@@ -1,1 +1,1 @@
-mercurial https://bitbucket.org/mackram/cl-cron
+git https://github.com/ciel-lang/cl-cron.git


### PR DESCRIPTION
…anymore

Link https://bitbucket.org/mackram/cl-cron returns 404 error now :(

# No pull requests

Please do not create pull requests for this repo.

If you would like to add, remove, or modify a project in Quicklisp,
please [open an
issue](https://github.com/quicklisp/quicklisp-projects/issues)
instead.

If you have any questions, feel free to [email me](mailto:zach@quicklisp.org).
